### PR TITLE
Set Emacs version for Cask to fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
     fi
   - emacs --version
   # Install Cask
-  - mkdir "$HOME"/bin # Cask is installed here
+  - mkdir -p "$HOME"/bin # Cask is installed here
   - wget 'https://raw.githubusercontent.com/flycheck/emacs-travis/master/emacs-travis.mk'
   - make -f emacs-travis.mk install_cask
   # Use Cask to install dependencies

--- a/Makefile
+++ b/Makefile
@@ -3,20 +3,20 @@ TRAVIS_FILE=.travis.yml
 .PHONY : build test-travis test clean
 
 build :
-	cask build
+	EMACS=$(shell which emacs) cask build
 
 test-travis :
 	@if test -z "$$TRAVIS" && test -e $(TRAVIS_FILE); then travis lint $(TRAVIS_FILE); fi
 
 install:
-	cask install
+	EMACS=$(shell which emacs) cask install
 
 install-dev:
 	@echo "Using emacs from $(shell which emacs)"
 	EMACS=$(shell which emacs) cask install --dev
 
 test :
-	cask exec ert-runner --verbose --debug -l ob-async.el
+	EMACS=$(shell which emacs) cask exec ert-runner --verbose --debug -l ob-async.el
 
 clean :
 	@rm -f *.elc *~ */*.elc */*~

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ install:
 	cask install
 
 install-dev:
-	cask install --dev
+	@echo "Using emacs from $(shell which emacs)"
+	EMACS=$(shell which emacs) cask install --dev
 
 test :
 	cask exec ert-runner --verbose --debug -l ob-async.el


### PR DESCRIPTION
Cask was using Emacs 24.3, but `add-advice` wasn't added until Emacs 24.4. The fact that we were using Emacs 24.3 was a mistake. Setting the Emacs version explicitly in the invocation of Cask fixes the build.