### PR TITLE
Confirm evaluation before inserting RESULTS block

### DIFF
--- a/ob-async.org
+++ b/ob-async.org
@@ -186,60 +186,60 @@ escapes and captures in the async macros. And it actually works!
   block."
     (interactive)
     (let* ((org-babel-current-src-block-location
-	    (or org-babel-current-src-block-location
-	        (nth 5 info)
-	        (org-babel-where-is-src-block-head)))
-	   (info (if info (copy-tree info) (org-babel-get-src-block-info))))
+            (or org-babel-current-src-block-location
+                (nth 5 info)
+                (org-babel-where-is-src-block-head)))
+           (info (if info (copy-tree info) (org-babel-get-src-block-info))))
       ;; Merge PARAMS with INFO before considering source block
       ;; evaluation since both could disagree.
       (cl-callf org-babel-merge-params (nth 2 info) params)
       (when (org-babel-check-evaluate info)
         (cl-callf org-babel-process-params (nth 2 info))
         (let* ((params (nth 2 info))
-	       (cache (let ((c (cdr (assq :cache params))))
-		        (and (not arg) c (string= "yes" c))))
-	       (new-hash (and cache (org-babel-sha1-hash info)))
-	       (old-hash (and cache (org-babel-current-result-hash)))
-	       (current-cache (and new-hash (equal new-hash old-hash))))
-	  (cond
-	   (current-cache
-	    (save-excursion		;Return cached result.
-	      (goto-char (org-babel-where-is-src-block-result nil info))
-	      (forward-line)
-	      (skip-chars-forward " \t")
-	      (let ((result (org-babel-read-result)))
-	        (message (replace-regexp-in-string "%" "%%" (format "%S" result)))
-	        result)))
-	   ((org-babel-confirm-evaluate info)
-	    (let* ((lang (nth 0 info))
-		   (result-params (cdr (assq :result-params params)))
-		   ;; Expand noweb references in BODY and remove any
-		   ;; coderef.
-		   (body
-		    (let ((coderef (nth 6 info))
-			  (expand
-			   (if (org-babel-noweb-p params :eval)
-			       (org-babel-expand-noweb-references info)
-			     (nth 1 info))))
-		      (if (not coderef) expand
-		        (replace-regexp-in-string
-		         (org-src-coderef-regexp coderef) "" expand nil nil 1))))
-		   (dir (cdr (assq :dir params)))
-		   (default-directory
-		     (or (and dir (file-name-as-directory (expand-file-name dir)))
-		         default-directory))
-		   (cmd (intern (concat "org-babel-execute:" lang)))
-		   result)
-	      (unless (fboundp cmd)
-	        (error "No org-babel-execute function for %s!" lang))
-	      (message "executing %s code block%s..."
-		       (capitalize lang)
-		       (let ((name (nth 4 info)))
-		         (if name (format " (%s)" name) "")))
-	      (if (member "none" result-params)
-		  (progn (funcall cmd body params)
-		         (message "result silenced"))
-	        (progn
+               (cache (let ((c (cdr (assq :cache params))))
+                        (and (not arg) c (string= "yes" c))))
+               (new-hash (and cache (org-babel-sha1-hash info)))
+               (old-hash (and cache (org-babel-current-result-hash)))
+               (current-cache (and new-hash (equal new-hash old-hash))))
+          (cond
+           (current-cache
+            (save-excursion ; Return cached result.
+              (goto-char (org-babel-where-is-src-block-result nil info))
+              (forward-line)
+              (skip-chars-forward " \t")
+              (let ((result (org-babel-read-result)))
+                (message (replace-regexp-in-string "%" "%%" (format "%S" result)))
+                result)))
+           ((org-babel-confirm-evaluate info)
+            (let* ((lang (nth 0 info))
+                   (result-params (cdr (assq :result-params params)))
+                   ;; Expand noweb references in BODY and remove any
+                   ;; coderef.
+                   (body
+                    (let ((coderef (nth 6 info))
+                          (expand
+                           (if (org-babel-noweb-p params :eval)
+                               (org-babel-expand-noweb-references info)
+                             (nth 1 info))))
+                      (if (not coderef) expand
+                        (replace-regexp-in-string
+                         (org-src-coderef-regexp coderef) "" expand nil nil 1))))
+                   (dir (cdr (assq :dir params)))
+                   (default-directory
+                     (or (and dir (file-name-as-directory (expand-file-name dir)))
+                         default-directory))
+                   (cmd (intern (concat "org-babel-execute:" lang)))
+                   result)
+              (unless (fboundp cmd)
+                (error "No org-babel-execute function for %s!" lang))
+              (message "executing %s code block%s..."
+                       (capitalize lang)
+                       (let ((name (nth 4 info)))
+                         (if name (format " (%s)" name) "")))
+              (if (member "none" result-params)
+                  (progn (funcall cmd body params)
+                         (message "result silenced"))
+                (progn
                   (async-start
                    `(lambda ()
                       (setq exec-path (append exec-path '("~/.emacs.d/elpa")))
@@ -250,12 +250,12 @@ escapes and captures in the async macros. And it actually works!
                          (shell . t)))
                       (,cmd ,body ',params))
                    `(lambda (result)
-                     (message "Async done: %s" result)
-                     (switch-to-buffer ,(current-buffer))
-                     (goto-char ,(point))
-                     (org-babel-insert-result result)
-                     (message "Insert done: %s" result)
-                     (run-hooks 'org-babel-after-execute-hook))))))))))))
+                      (message "Async done: %s" result)
+                      (switch-to-buffer ,(current-buffer))
+                      (goto-char ,(point))
+                      (org-babel-insert-result result)
+                      (message "Insert done: %s" result)
+                      (run-hooks 'org-babel-after-execute-hook))))))))))))
 #+END_SRC
 #+RESULTS:
 : org-babel-execute-src-block-mine
@@ -313,6 +313,8 @@ the #+RESULTS block.
   ;;; Code:
 #+END_SRC
 
+#+RESULTS:
+
 * Implementation
 :PROPERTIES:
 :header-args: :tangle ob-async.el
@@ -336,7 +338,7 @@ I'd also like to test this with ERT.
 #+END_SRC
 
 #+RESULTS:
-: ob-async
+: async
 
 ** Acceptance Tests
 :PROPERTIES:
@@ -699,6 +701,27 @@ in a results block, then delete it once the command completes.
 #+RESULTS:
 : test-async-execute-call
 
+*** Confirmation of evaluation
+
+#+BEGIN_SRC emacs-lisp
+  (ert-deftest test-confirm-evaluate ()
+    "Test that we do not add a RESULTS block if evaluation is not confirmed"
+    (let ((buffer-contents "
+    ,#+BEGIN_SRC sh :async
+       sleep 1s && echo 'Sorry for the wait.'
+    ,#+END_SRC")
+          (org-confirm-babel-evaluate t)
+          (org-babel-confirm-evaluate-answer-no t))
+      (with-buffer-contents buffer-contents
+                              (org-babel-next-src-block)
+                              (org-ctrl-c-ctrl-c)
+                              (should (not (org-babel-where-is-src-block-result))))))
+#+END_SRC
+
+#+RESULTS:
+: test-confirm-evaluate
+
+
 ** Definition
 
 I didn't follow the standard naming convention when I named this
@@ -709,6 +732,9 @@ anyone's ctrl-c ctrl-c hooks.
   ;;;###autoload
   (defalias 'org-babel-execute-src-block:async 'ob-async-org-babel-execute-src-block)
 #+END_SRC
+
+#+RESULTS:
+: org-babel-execute-src-block:async
 
 If the header contains ~:async~, we'll steal the command before it
 gets to ~org-babel-execute-src-block~. The guts of this function are
@@ -748,109 +774,113 @@ ripped straight from the original source for
      ;; Otherwise, perform asynchronous execution
      (t
       (let ((placeholder (ob-async--generate-uuid)))
-	(org-babel-insert-result placeholder '("replace"))
-	;; This is the original source of org-babel-execute-src-block
-	(let* ((org-babel-current-src-block-location
-	      (or org-babel-current-src-block-location
-		  (nth 5 info)
-		  (org-babel-where-is-src-block-head)))
-	     (info (if info (copy-tree info) (org-babel-get-src-block-info))))
-	;; Merge PARAMS with INFO before considering source block
-	;; evaluation since both could disagree.
-	(cl-callf org-babel-merge-params (nth 2 info) params)
-	(when (org-babel-check-evaluate info)
-	  (cl-callf org-babel-process-params (nth 2 info))
-	  (let* ((params (nth 2 info))
-		 (cache (let ((c (cdr (assq :cache params))))
-			  (and (not arg) c (string= "yes" c))))
-		 (new-hash (and cache (org-babel-sha1-hash info)))
-		 (old-hash (and cache (org-babel-current-result-hash)))
-		 (current-cache (and new-hash (equal new-hash old-hash))))
-	    (cond
-	     (current-cache
-	      (save-excursion		;Return cached result.
-		(goto-char (org-babel-where-is-src-block-result nil info))
-		(forward-line)
-		(skip-chars-forward " \t")
-		(let ((result (org-babel-read-result)))
-		  (message (replace-regexp-in-string "%" "%%" (format "%S" result)))
-		  result)))
-	     ((org-babel-confirm-evaluate info)
-	      (let* ((lang (nth 0 info))
-		     (result-params (cdr (assq :result-params params)))
-		     ;; Expand noweb references in BODY and remove any
-		     ;; coderef.
-		     (body
-		      (let ((coderef (nth 6 info))
-			    (expand
-			     (if (org-babel-noweb-p params :eval)
-				 (org-babel-expand-noweb-references info)
-			       (nth 1 info))))
-			(if (not coderef) expand
-			  (replace-regexp-in-string
-			   (org-src-coderef-regexp coderef) "" expand nil nil 1))))
-		     (dir (cdr (assq :dir params)))
-		     (default-directory
-		       (or (and dir (file-name-as-directory (expand-file-name dir)))
-			   default-directory))
-		     (cmd (intern (concat "org-babel-execute:" lang)))
-		     result)
-		(unless (fboundp cmd)
-		  (error "No org-babel-execute function for %s!" lang))
-		(message "executing %s code block%s..."
-			 (capitalize lang)
-			 (let ((name (nth 4 info)))
-			   (if name (format " (%s)" name) "")))
-		  (progn
+        ;; Here begins the original source of org-babel-execute-src-block
+        (let* ((org-babel-current-src-block-location
+                (or org-babel-current-src-block-location
+                    (nth 5 info)
+                    (org-babel-where-is-src-block-head)))
+               (info (if info (copy-tree info) (org-babel-get-src-block-info))))
+          ;; Merge PARAMS with INFO before considering source block
+          ;; evaluation since both could disagree.
+          (cl-callf org-babel-merge-params (nth 2 info) params)
+          (when (org-babel-check-evaluate info)
+            (cl-callf org-babel-process-params (nth 2 info))
+            (let* ((params (nth 2 info))
+                   (cache (let ((c (cdr (assq :cache params))))
+                            (and (not arg) c (string= "yes" c))))
+                   (new-hash (and cache (org-babel-sha1-hash info)))
+                   (old-hash (and cache (org-babel-current-result-hash)))
+                   (current-cache (and new-hash (equal new-hash old-hash))))
+              (cond
+               (current-cache
+                (save-excursion		;Return cached result.
+                  (goto-char (org-babel-where-is-src-block-result nil info))
+                  (forward-line)
+                  (skip-chars-forward " \t")
+                  (let ((result (org-babel-read-result)))
+                    (message (replace-regexp-in-string "%" "%%" (format "%S" result)))
+                    result)))
+               ((org-babel-confirm-evaluate info)
+                ;; Insert a GUID as a placeholder in our RESULTS block
+                (org-babel-insert-result placeholder '("replace"))
+                (let* ((lang (nth 0 info))
+                       (result-params (cdr (assq :result-params params)))
+                       ;; Expand noweb references in BODY and remove any
+                       ;; coderef.
+                       (body
+                        (let ((coderef (nth 6 info))
+                              (expand
+                               (if (org-babel-noweb-p params :eval)
+                                   (org-babel-expand-noweb-references info)
+                                 (nth 1 info))))
+                          (if (not coderef) expand
+                            (replace-regexp-in-string
+                             (org-src-coderef-regexp coderef) "" expand nil nil 1))))
+                       (dir (cdr (assq :dir params)))
+                       (default-directory
+                         (or (and dir (file-name-as-directory (expand-file-name dir)))
+                             default-directory))
+                       (cmd (intern (concat "org-babel-execute:" lang)))
+                       result)
+                  (unless (fboundp cmd)
+                    (error "No org-babel-execute function for %s!" lang))
+                  (message "executing %s code block%s..."
+                           (capitalize lang)
+                           (let ((name (nth 4 info)))
+                             (if name (format " (%s)" name) "")))
+                  (progn
                     (async-start
                      `(lambda ()
-			;; TODO: Put this in a function so it can be overidden
-			;; Initialize the new Emacs process with org-babel functions
-			(setq exec-path ',exec-path)
-			(package-initialize)
-			(org-babel-do-load-languages 'org-babel-load-languages ',org-babel-load-languages)
-			(let ((default-directory ,default-directory))
-			  (,cmd ,body ',params)))
+                        ;; TODO: Put this in a function so it can be overidden
+                        ;; Initialize the new Emacs process with org-babel functions
+                        (setq exec-path ',exec-path)
+                        (package-initialize)
+                        (org-babel-do-load-languages 'org-babel-load-languages ',org-babel-load-languages)
+                        (let ((default-directory ,default-directory))
+                          (,cmd ,body ',params)))
                      (if (member "none" ',result-params)
-			 (progn (message "result silenced")
-				'ignore)
+                         (progn (message "result silenced")
+                                'ignore)
                        `(lambda (result)
-			  (switch-to-buffer ,(current-buffer))
-			  (point-to-register 13) ;; TODO: totally arbitrary choice of register
-			  (goto-char (point-min))
-			  (re-search-forward ,placeholder)
-			  (org-backward-element)
-			  (let ((result-block (split-string (thing-at-point 'line t))))
-			    ;; If block has name, search by name
-			    (-if-let (block-name (nth 1 result-block))
-			        (org-babel-goto-named-src-block block-name)
-			      (org-backward-element)))
-			  (let ((file (cdr (assq :file ',params))))
+                          (switch-to-buffer ,(current-buffer))
+                          (point-to-register 13) ;; TODO: totally arbitrary choice of register
+                          (goto-char (point-min))
+                          (re-search-forward ,placeholder)
+                          (org-backward-element)
+                          (let ((result-block (split-string (thing-at-point 'line t))))
+                            ;; If block has name, search by name
+                            (-if-let (block-name (nth 1 result-block))
+                                (org-babel-goto-named-src-block block-name)
+                              (org-backward-element)))
+                          (let ((file (cdr (assq :file ',params))))
                             ;; If non-empty result and :file then write to :file.
                             (when file
                               (when result
-				(with-temp-file file
-				  (insert (org-babel-format-result
-					   result (cdr (assq :sep ',params))))))
+                                (with-temp-file file
+                                  (insert (org-babel-format-result
+                                           result (cdr (assq :sep ',params))))))
                               (setq result file))
                             ;; Possibly perform post process provided its
                             ;; appropriate.  Dynamically bind "*this*" to the
                             ;; actual results of the block.
                             (let ((post (cdr (assq :post ',params))))
                               (when post
-				(let ((*this* (if (not file) result
-						(org-babel-result-to-file
-						 file
-						 (let ((desc (assq :file-desc ',params)))
-						   (and desc (or (cdr desc) result)))))))
-				  (setq result (org-babel-ref-resolve post))
-				  (when file
+                                (let ((*this* (if (not file) result
+                                                (org-babel-result-to-file
+                                                 file
+                                                 (let ((desc (assq :file-desc ',params)))
+                                                   (and desc (or (cdr desc) result)))))))
+                                  (setq result (org-babel-ref-resolve post))
+                                  (when file
                                     (setq result-params (remove "file" ',result-params))))))
                             (org-babel-insert-result result ',result-params ',info ',new-hash ',lang)
                             (run-hooks 'org-babel-after-execute-hook))
-                            (goto-char (point-min))
-                            (jump-to-register 13)))))))))))))))
+                          (goto-char (point-min))
+                          (jump-to-register 13)))))))))))))))
 #+END_SRC
+
+#+RESULTS:
+: ob-async-org-babel-execute-src-block
 
 Our UUID is just a random MD5 hash, which is 32 characters.
 
@@ -861,13 +891,15 @@ Our UUID is just a random MD5 hash, which is 32 characters.
 #+END_SRC
 
 #+RESULTS:
-: generate-uuid
+: ob-async--generate-uuid
 
 Advise all org-babel executions for potential asynchronicity.
 
 #+BEGIN_SRC emacs-lisp
   (advice-add 'org-babel-execute-src-block :around 'ob-async-org-babel-execute-src-block)
 #+END_SRC
+
+#+RESULTS:
 
 ** Test Harness
 
@@ -876,6 +908,9 @@ Advise all org-babel executions for potential asynchronicity.
   (setq org-confirm-babel-evaluate nil)
   (message "org-version: %s" (org-version))
 #+END_SRC
+
+#+RESULTS:
+: org-version: 9.0.9
 
 * CI
 :PROPERTIES:
@@ -930,6 +965,48 @@ we take =async= from elpa.
       on_failure: always # The default.
 #+END_SRC
 
+#+RESULTS:
+#+begin_example
+language: generic
+sudo: required
+git:
+  submodules: false
+
+env:
+  - EMACS_VERSION=24.5
+  - EMACS_VERSION=25-prerelease
+
+install:
+  - curl -LO https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
+  - tar -xaf emacs-bin-${EMACS_VERSION}.tar.gz -C /
+  # Configure $PATH: Emacs installed to /tmp/emacs
+  - export PATH=/tmp/emacs/bin:${PATH}
+  - if ! emacs -Q --batch --eval "(require 'cl-lib)" ; then
+        curl -Lo cl-lib.el http://elpa.gnu.org/packages/cl-lib-0.5.el ;
+        export warnings="'(not cl-functions)" ;
+    fi
+  - if ! emacs -Q --batch --eval "(require 'ert)" ; then
+        curl -LO https://raw.githubusercontent.com/ohler/ert/c619b56c5bc6a866e33787489545b87d79973205/lisp/emacs-lisp/ert.el &&
+        curl -LO https://raw.githubusercontent.com/ohler/ert/c619b56c5bc6a866e33787489545b87d79973205/lisp/emacs-lisp/ert-x.el ;
+    fi
+  - emacs --version
+  # Install Cask
+  - mkdir -p "$HOME"/bin # Cask is installed here
+  - wget 'https://raw.githubusercontent.com/flycheck/emacs-travis/master/emacs-travis.mk'
+  - make -f emacs-travis.mk install_cask
+  # Use Cask to install dependencies
+  - make install-dev
+
+script:
+  - make test
+
+notifications:
+  email:
+    # Default is change, but that includes a new branch's 1st success.
+    on_success: never
+    on_failure: always # The default.
+#+end_example
+
 * Footer
 :PROPERTIES:
 :header-args: :tangle ob-async.el
@@ -938,6 +1015,8 @@ we take =async= from elpa.
 #+BEGIN_SRC emacs-lisp :tangle ob-async.el
   ;;; ob-async.el ends here
 #+END_SRC
+
+#+RESULTS:
 
 * COMMENT Local Variables
 # Local Variables:

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -252,3 +252,16 @@ for row in x:
 			    (should (placeholder-p (results-block-contents position)))
 			    (wait-for-seconds 5)
 			    (should (string= "Sorry for the wait." (results-block-contents position)))))))
+
+(ert-deftest test-confirm-evaluate ()
+  "Test that we do not add a RESULTS block if evaluation is not confirmed"
+  (let ((buffer-contents "
+  #+BEGIN_SRC sh :async
+     sleep 1s && echo 'Sorry for the wait.'
+  #+END_SRC")
+        (org-confirm-babel-evaluate t)
+        (org-babel-confirm-evaluate-answer-no t))
+    (with-buffer-contents buffer-contents
+                            (org-babel-next-src-block)
+                            (org-ctrl-c-ctrl-c)
+                            (should (not (org-babel-where-is-src-block-result))))))


### PR DESCRIPTION
If `org-confirm-babel-evaluate` is non-nil, we should wait for
confirmation before inserting a #+RESULTS block.

Addresses https://github.com/astahlman/ob-async/issues/23