### PR TITLE
Add explicit dependency on dash

### DIFF
--- a/Cask
+++ b/Cask
@@ -5,6 +5,7 @@
 
 (depends-on "org-plus-contrib")
 (depends-on "async")
+(depends-on "dash")
 
 (development
  (depends-on "f")

--- a/ob-async.el
+++ b/ob-async.el
@@ -24,7 +24,7 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-;; Package-Requires: ((async "1.9") (org "9.0.1") (emacs "24.4"))
+;; Package-Requires: ((async "1.9") (org "9.0.1") (emacs "24.4") (dash "2.14.1"))
 
 ;;; Commentary:
 ;; This file enables asynchronous execution of org-babel
@@ -36,6 +36,7 @@
 
 (require 'org)
 (require 'async)
+(require 'dash)
 
 ;;;###autoload
 (defalias 'org-babel-execute-src-block:async 'ob-async-org-babel-execute-src-block)

--- a/ob-async.org
+++ b/ob-async.org
@@ -304,7 +304,7 @@ the #+RESULTS block.
   ;; You should have received a copy of the GNU General Public License
   ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-  ;; Package-Requires: ((async "1.9") (org "9.0.1") (emacs "24.4"))
+  ;; Package-Requires: ((async "1.9") (org "9.0.1") (emacs "24.4") (dash "2.14.1"))
 
   ;;; Commentary:
   ;; This file enables asynchronous execution of org-babel
@@ -333,6 +333,7 @@ I'd also like to test this with ERT.
 
   (require 'org)
   (require 'async)
+  (require 'dash)
 #+END_SRC
 
 #+RESULTS:


### PR DESCRIPTION
We've been using the `-if-let` macro from dash.el without every
explicitly requiring the dash library. dash is a common library, so
we've gotten away with it until now - see [1].

[1] https://github.com/astahlman/ob-async/issues/25