### PR TITLE
ob-async: use with-current-buffer to update org buffer

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -142,41 +142,39 @@ block."
                        (progn (message "result silenced")
                               'ignore)
                      `(lambda (result)
-                        (switch-to-buffer ,(current-buffer))
-                        (point-to-register 13) ;; TODO: totally arbitrary choice of register
-                        (goto-char (point-min))
-                        (re-search-forward ,placeholder)
-                        (org-backward-element)
-                        (let ((result-block (split-string (thing-at-point 'line t))))
-                          ;; If block has name, search by name
-                          (-if-let (block-name (nth 1 result-block))
-                              (org-babel-goto-named-src-block block-name)
-                            (org-backward-element)))
-                        (let ((file (cdr (assq :file ',params))))
-                          ;; If non-empty result and :file then write to :file.
-                          (when file
-                            (when result
-                              (with-temp-file file
-                                (insert (org-babel-format-result
-                                         result (cdr (assq :sep ',params))))))
-                            (setq result file))
-                          ;; Possibly perform post process provided its
-                          ;; appropriate.  Dynamically bind "*this*" to the
-                          ;; actual results of the block.
-                          (let ((post (cdr (assq :post ',params))))
-                            (when post
-                              (let ((*this* (if (not file) result
-                                              (org-babel-result-to-file
-                                               file
-                                               (let ((desc (assq :file-desc ',params)))
-                                                 (and desc (or (cdr desc) result)))))))
-                                (setq result (org-babel-ref-resolve post))
-                                (when file
-                                  (setq result-params (remove "file" ',result-params))))))
-                          (org-babel-insert-result result ',result-params ',info ',new-hash ',lang)
-                          (run-hooks 'org-babel-after-execute-hook))
-                        (goto-char (point-min))
-                        (jump-to-register 13)))))))))))))))
+			(with-current-buffer ,(current-buffer)
+                          (save-excursion
+                            (goto-char (point-min))
+                            (re-search-forward ,placeholder)
+                            (org-backward-element)
+                            (let ((result-block (split-string (thing-at-point 'line t))))
+                              ;; If block has name, search by name
+                              (-if-let (block-name (nth 1 result-block))
+                                  (org-babel-goto-named-src-block block-name)
+                                (org-backward-element)))
+                            (let ((file (cdr (assq :file ',params))))
+                              ;; If non-empty result and :file then write to :file.
+                              (when file
+                                (when result
+                                  (with-temp-file file
+                                    (insert (org-babel-format-result
+                                             result (cdr (assq :sep ',params))))))
+                                (setq result file))
+                              ;; Possibly perform post process provided its
+                              ;; appropriate.  Dynamically bind "*this*" to the
+                              ;; actual results of the block.
+                              (let ((post (cdr (assq :post ',params))))
+                                (when post
+                                  (let ((*this* (if (not file) result
+                                                  (org-babel-result-to-file
+                                                   file
+                                                   (let ((desc (assq :file-desc ',params)))
+                                                     (and desc (or (cdr desc) result)))))))
+                                    (setq result (org-babel-ref-resolve post))
+                                    (when file
+                                      (setq result-params (remove "file" ',result-params))))))
+                              (org-babel-insert-result result ',result-params ',info ',new-hash ',lang)
+                              (run-hooks 'org-babel-after-execute-hook))))))))))))))))))
 
 (defun ob-async--generate-uuid ()
   "Generate a 32 character UUID."


### PR DESCRIPTION
Currently when updating the results buffer the user might get
surprised if they are in the middle of typing. This is because using
switch-to-buffer will interfere with interactive typing, as the
documentation notes:

  WARNING: This is NOT the way to work on another buffer temporarily
within a Lisp program!

Rather than using set-buffer though we can simply use
the (with-current-buffer) wrapper. This also means we don't need the
register hack to save our position. The user will still see the "Code
block evaluation complete." message appear in the miibuffer but we
could make a cleaner message. This is left as an exercise for a later
patch.

Signed-off-by: Alex Bennée <alex.bennee@linaro.org>