### PR TITLE
Add list of languages for ob-async to ignore

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -38,6 +38,9 @@
 (require 'async)
 (require 'dash)
 
+(defvar ob-async-no-async-languages-alist nil
+  "async is not used for languages listed here. Enables compatability for other languages, e.g. ipython, for which async functionality may be implemented separately.")
+
 ;;;###autoload
 (defalias 'org-babel-execute-src-block:async 'ob-async-org-babel-execute-src-block)
 
@@ -69,6 +72,11 @@ block."
     nil)
    ;; If there is no :async parameter, call the original function
    ((not (assoc :async (nth 2 (or info (org-babel-get-src-block-info)))))
+    (funcall orig-fun arg info params))
+   ;; If the src block language is in the list of languages async is not to be
+   ;; used for, call the original function
+   ((member (nth 0 (or info (org-babel-get-src-block-info)))
+	    ob-async-no-async-languages-alist)
     (funcall orig-fun arg info params))
    ;; Otherwise, perform asynchronous execution
    (t

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -50,13 +50,13 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
 
 
 (ert-deftest test-async-ignore-lang-sh-block ()
-  "Test that we can insert results for a sh block that hasn't been executed yet"
+  "Testing ignoring a language."
   (let ((buffer-contents "Here's a shell source block:
 
   #+BEGIN_SRC sh :async
       sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC")
-	(org-async-no-async-languages-alist '("sh")))
+	(ob-async-no-async-languages-alist '("sh")))
     (with-buffer-contents buffer-contents
                           (org-babel-next-src-block)
                           (org-ctrl-c-ctrl-c)

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -48,6 +48,20 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
                           (wait-for-seconds 5)
                           (should (string= "Sorry for the wait." (results-block-contents))))))
 
+
+(ert-deftest test-async-ignore-lang-sh-block ()
+  "Test that we can insert results for a sh block that hasn't been executed yet"
+  (let ((buffer-contents "Here's a shell source block:
+
+  #+BEGIN_SRC sh :async
+      sleep 1s && echo 'Sorry for the wait.'
+  #+END_SRC")
+	(org-async-no-async-languages-alist '("sh")))
+    (with-buffer-contents buffer-contents
+                          (org-babel-next-src-block)
+                          (org-ctrl-c-ctrl-c)
+                          (should (string= "Sorry for the wait." (results-block-contents))))))
+
 (ert-deftest test-async-execute-existing-sh-block ()
   "Test that we can insert results for a sh block that has already been executed"
   (let ((buffer-contents "Here's a shell source block:


### PR DESCRIPTION
I recently noticed an incompatibility between this and the [`ob-ipython` package](https://github.com/gregsexton/ob-ipython), which defines its own `:async` keyword (and keeps an open pipe to an ipython session running in the background). To remedy this, I have added an elisp variable `ob-async-no-async-languages-alist` here: for any languages included in this list, the original `ctrl-c-ctrl-c` function is run — as it is for src blocks that do not include the `:async` keyword. By default, the variable is set to `nil`, so that there are no changes to the default behavior of `ob-ipython`.

I've also included a test to show this functionality in action. By setting `ob-async-no-async-languages-alist` to `'("sh")`, we can run one of the core tests, but expect that the code will finish before the check is run, circumventing the `:async` keyword.

Let me know if something seems amiss, and I'm happy to update this. (...and thanks for writing this package; I use it all the time.)