### PR TITLE
Add a pre-execute hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,49 @@ includes `:async` in its header-args.
 
     (require 'ob-async)
 
+## Configuration
+
+`ob-async` should work with no additional setup for most
+languages. However, there are a few known edge-cases which require
+extra configuration.
+
+### ob-async-no-async-languages-alist
+
+Some org-babel languages (e.g., `ob-python`) define their own `:async`
+keyword that conflicts with `ob-async`. `ob-async` will ignore any
+languages in this blacklist, even if the `:async` keywords is
+present. Note that the `-alist` suffix is misleading; this variable
+actually represents a plain list and will be renamed in a future
+release.
+
+Example:
+
+    (setq ob-async-no-async-languages-alist '("ipython"))
+
+For additional context, see
+https://github.com/astahlman/ob-async/pull/35.
+
+### ob-async-pre-execute-src-block-hook
+
+Some org-babel languages require additional user configuration. For
+example, `ob-julia` requires `inferior-julia-program-name` to be
+defined. Normally you would define such variables in your `init.el`,
+but src block execution occurs in an Emacs subprocess which does not
+evaluate `init.el` on startup. Instead, you can place initialization
+logic in `ob-async-pre-execute-src-block-hook`, which runs before
+execution of every src block.
+
+Example:
+
+    (add-hook 'ob-async-pre-execute-src-block-hook
+            '(lambda ()
+               (setq inferior-julia-program-name "/usr/local/bin/julia")))
+
+
+For additional context, see
+https://github.com/astahlman/ob-async/issues/37 and
+https://github.com/jwiegley/emacs-async/pull/73.
+
 ## Development
 
 [Cask](https://github.com/cask/cask) manages dependencies and runs

--- a/ob-async.el
+++ b/ob-async.el
@@ -39,7 +39,14 @@
 (require 'dash)
 
 (defvar ob-async-no-async-languages-alist nil
-  "async is not used for languages listed here. Enables compatability for other languages, e.g. ipython, for which async functionality may be implemented separately.")
+  "async is not used for languages listed here. Enables
+compatibility for other languages, e.g. ipython, for which async
+functionality may be implemented separately.")
+
+(defvar ob-async-pre-execute-src-block-hook nil
+  "Hook run in the async child process prior to executing a src
+block. You can use this hook to perform language-specific
+initialization which would normally execute in your init file.")
 
 ;;;###autoload
 (defalias 'org-babel-execute-src-block:async 'ob-async-org-babel-execute-src-block)
@@ -76,7 +83,7 @@ block."
    ;; If the src block language is in the list of languages async is not to be
    ;; used for, call the original function
    ((member (nth 0 (or info (org-babel-get-src-block-info)))
-	    ob-async-no-async-languages-alist)
+            ob-async-no-async-languages-alist)
     (funcall orig-fun arg info params))
    ;; Otherwise, perform asynchronous execution
    (t
@@ -143,6 +150,8 @@ block."
                       (setq exec-path ',exec-path)
                       (setq load-path ',load-path)
                       (package-initialize)
+                      (setq ob-async-pre-execute-src-block-hook ',ob-async-pre-execute-src-block-hook)
+                      (run-hooks 'ob-async-pre-execute-src-block-hook)
                       (org-babel-do-load-languages 'org-babel-load-languages ',org-babel-load-languages)
                       (let ((default-directory ,default-directory))
                         (,cmd ,body ',params)))

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -279,3 +279,17 @@ for row in x:
                           (org-babel-next-src-block)
                           (org-ctrl-c-ctrl-c)
                           (should (not (org-babel-where-is-src-block-result))))))
+
+(ert-deftest test-pre-execute-hook ()
+  "Test that we can use a hook to perform setup before async execution"
+  (let ((buffer-contents "
+  #+BEGIN_SRC emacs-lisp :async
+     (funcall this-function-is-defined-in-a-hook 1 1)
+  #+END_SRC")
+        (ob-async-pre-execute-src-block-hook '((lambda ()
+                                                 (setq this-function-is-defined-in-a-hook #'+)))))
+    (with-buffer-contents buffer-contents
+                          (org-babel-next-src-block)
+                          (org-ctrl-c-ctrl-c)
+                          (wait-for-seconds 5)
+                          (should (= 2 (results-block-contents))))))


### PR DESCRIPTION
Add a hook that runs before the src block is executed. This hook enables users to perform package-specific initialization that would normally be handled in `init.el`. See https://github.com/astahlman/ob-async/issues/37 for a motivating example.