### PR TITLE
Make test case work with python 2 and 3

### DIFF
--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -169,7 +169,7 @@ when content has been added below the source block"
 #+BEGIN_SRC python :results output table :async t
 x = [['{},{}    '.format(i, j) for j in range(1, 3)] for i in range(1, 3)]
 for row in x:
-    print '{}\\n'.format(x)
+    print('{}\\n'.format(x))
 #+END_SRC"))
     (with-buffer-contents buffer-contents
                           (org-babel-next-src-block)


### PR DESCRIPTION
This test case was using `print`, which produces a syntax error if the
default system Python interpreter is python3. `print()` should
work for both python2 and python3.