### PR TITLE
Use marker to keep track of src_block

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -93,6 +93,9 @@ block."
               (or org-babel-current-src-block-location
                   (nth 5 info)
                   (org-babel-where-is-src-block-head)))
+             (src-block-marker (save-excursion
+                                 (goto-char org-babel-current-src-block-location)
+                                 (point-marker)))
              (info (if info (copy-tree info) (org-babel-get-src-block-info))))
         ;; Merge PARAMS with INFO before considering source block
         ;; evaluation since both could disagree.
@@ -162,7 +165,7 @@ block."
                         (with-current-buffer ,(current-buffer)
                           (let ((default-directory ,default-directory))
                             (save-excursion
-                              (goto-char ,org-babel-current-src-block-location)
+                              (goto-char ,src-block-marker)
                               (let ((file (cdr (assq :file ',params))))
                                 ;; If non-empty result and :file then write to :file.
                                 (when file

--- a/ob-async.el
+++ b/ob-async.el
@@ -162,14 +162,7 @@ block."
                         (with-current-buffer ,(current-buffer)
                           (let ((default-directory ,default-directory))
                             (save-excursion
-                              (goto-char (point-min))
-                              (re-search-forward ,placeholder)
-                              (org-backward-element)
-                              (let ((result-block (split-string (thing-at-point 'line t))))
-                                ;; If block has name, search by name
-                                (-if-let (block-name (nth 1 result-block))
-                                    (org-babel-goto-named-src-block block-name)
-                                  (org-backward-element)))
+                              (goto-char ,org-babel-current-src-block-location)
                               (let ((file (cdr (assq :file ',params))))
                                 ;; If non-empty result and :file then write to :file.
                                 (when file

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -1,4 +1,5 @@
 (require 'subr-x)
+(require 'cl-macs)
 
 (defun placeholder-p (s)
   "Return non-nil if S is a placeholder for an asynchronous result."
@@ -12,13 +13,13 @@ If NAME is non-nil, find the results block by name."
     (progn
       (if name
           (org-babel-goto-named-result name)
-        (if-let ((result-pos (org-babel-where-is-src-block-result)))
+        (-if-let ((result-pos (org-babel-where-is-src-block-result)))
             (goto-char result-pos)
-          (assert (progn
-                    (goto-char (point-min))
-                    (re-search-forward "#\\+RESULT"))
-                  nil
-                  "Couldn't find a RESULTS block")))
+          (cl-assert (progn
+                       (goto-char (point-min))
+                       (re-search-forward "#\\+RESULT"))
+                     nil
+                     "Couldn't find a RESULTS block")))
       (let ((result (org-babel-read-result)))
         (message "RESULTS: %s" result)
         result))))

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -4,17 +4,21 @@
   "Return non-nil if S is a placeholder for an asynchronous result."
   (and (= 32 (length s)) (string-match-p "^[a-z0-9]\\{32\\}$" s)))
 
-(defun results-block-contents (&optional position)
+(defun results-block-contents (&optional name)
   "Return the contents of the *only* results block in the buffer.
-Assume the source block is at POSITION if non-nil."
+If NAME is non-nil, find the results block by name."
   (interactive)
   (save-excursion
     (progn
-      (if position
-          (goto-char position)
-        (goto-char 0)
-        (org-babel-next-src-block))
-      (goto-char (org-babel-where-is-src-block-result))
+      (if name
+          (org-babel-goto-named-result name)
+        (if-let ((result-pos (org-babel-where-is-src-block-result)))
+            (goto-char result-pos)
+          (assert (progn
+                    (goto-char (point-min))
+                    (re-search-forward "#\\+RESULT"))
+                  nil
+                  "Couldn't find a RESULTS block")))
       (let ((result (org-babel-read-result)))
         (message "RESULTS: %s" result)
         result))))
@@ -248,6 +252,36 @@ for row in x:
                                                      (point-marker))))
                             (should (< results-block-pos src-block-pos))))))
 
+(ert-deftest test-async-execute-named-call-block ()
+  "Test that we can asynchronously execute a named call block ."
+  (let ((buffer-contents "
+  #+NAME: test
+  #+CALL: async-block()
+
+  Here's a shell source block:
+
+  #+NAME: async-block
+  #+BEGIN_SRC sh :async
+     echo 'Sorry for the wait.'
+  #+END_SRC "))
+    (with-buffer-contents buffer-contents
+      (re-search-forward "#\\+NAME: test")
+      (org-ctrl-c-ctrl-c)
+      (let ((results-block-pos (save-excursion
+                                 (org-babel-goto-named-result "test")
+                                 (point-marker)))
+            (src-block-pos (save-excursion
+                             (org-babel-goto-named-src-block "async-block")
+                             (point-marker))))
+        (should (< results-block-pos src-block-pos))
+        (goto-char results-block-pos)
+        (should (placeholder-p (results-block-contents "test")))
+;(string-trim (org-element-property :value (org-element-at-point)))
+        (wait-for-seconds 5)
+        (should (string= "Sorry for the wait."
+                         (string-trim (org-element-property :value (org-element-at-point)))))))))
+
+
 (ert-deftest test-async-execute-silent-block ()
   "Test that we can insert results for a sh block that hasn't been executed yet"
   :expected-result :failed
@@ -273,11 +307,11 @@ for row in x:
 
   #+CALL: async-block()"))
     (with-buffer-contents buffer-contents
-                          (let ((position (re-search-forward "#\\+CALL")))
-                            (org-ctrl-c-ctrl-c)
-                            (should (placeholder-p (results-block-contents position)))
-                            (wait-for-seconds 5)
-                            (should (string= "Sorry for the wait." (results-block-contents position)))))))
+                          (re-search-forward "#\\+CALL")
+                          (org-ctrl-c-ctrl-c)
+                          (should (placeholder-p (results-block-contents)))
+                          (wait-for-seconds 5)
+                          (should (string= "Sorry for the wait." (results-block-contents))))))
 
 (ert-deftest test-confirm-evaluate ()
   "Test that we do not add a RESULTS block if evaluation is not confirmed"

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -212,7 +212,7 @@ for row in x:
 (ert-deftest test-async-execute-named-block ()
   "Test that we can asynchronously execute a block when cursor is on the name."
   (let ((buffer-contents "Here's a shell source block:
-  #+NAME: async-block
+  #+NAME: async block with spaces in the name
   #+BEGIN_SRC sh :async
      sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC"))
@@ -226,9 +226,9 @@ for row in x:
 (ert-deftest test-async-execute-named-block-with-results ()
   "Test that we can asynchronously execute a named block when results are anywhere in buffer."
   (let ((buffer-contents "Here's a shell source block:
-  #+RESULTS: async-block
+  #+RESULTS: async block with spaces in the name
 
-  #+NAME: async-block
+  #+NAME: async block with spaces in the name
   #+BEGIN_SRC sh :async
      sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC"))
@@ -237,7 +237,16 @@ for row in x:
                           (org-ctrl-c-ctrl-c)
                           (should (placeholder-p (results-block-contents)))
                           (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents))))))
+                          (should (string= "Sorry for the wait." (results-block-contents)))
+                          (let ((results-block-pos (save-excursion
+                                                     (goto-char (point-min))
+                                                     (re-search-forward "#\\+RESULTS")
+                                                     (point-marker)))
+                                (src-block-pos (save-excursion
+                                                     (goto-char (point-min))
+                                                     (re-search-forward "#\\+BEGIN_SRC")
+                                                     (point-marker))))
+                            (should (< results-block-pos src-block-pos))))))
 
 (ert-deftest test-async-execute-silent-block ()
   "Test that we can insert results for a sh block that hasn't been executed yet"

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -277,10 +277,9 @@ for row in x:
         (should (< results-block-pos src-block-pos))
         (goto-char results-block-pos)
         (should (placeholder-p (results-block-contents "test")))
-;(string-trim (org-element-property :value (org-element-at-point)))
         (wait-for-seconds 5)
         (should (string= "Sorry for the wait."
-                         (string-trim (org-element-property :value (org-element-at-point)))))))))
+                         (results-block-contents "test")))))))
 
 
 (ert-deftest test-async-execute-silent-block ()


### PR DESCRIPTION
The function `org-babel-insert-result` assumes that point is on the SRC_BLOCK that we are executing. This wasn't true, in our case - we were inserting/overwriting the RESULTS block with a placeholder GUID, then searching for the GUID in our results callback and putting point on the RESULTS block. This causes problems in some corner-cases, e.g., named SRC_BLOCKS with spaces in the names (see [1]).

Instead of marking our place in the buffer with a GUID, we can simplify thing by leaving ourselves a marker. We already know the location of the current SRC_BLOCK when we start execution - we just need to keep a reference to it in our callback function.

The GUID that we insert into the results block is serving no purpose now, so we could remove it or replace it with a more informative message. I'll leave it as-is for now and revisit later.

[1] https://github.com/astahlman/ob-async/issues/46