### PR TITLE
Use callbacks instead of fixed sleep in test cases 

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -93,6 +93,9 @@ block."
               (or org-babel-current-src-block-location
                   (nth 5 info)
                   (org-babel-where-is-src-block-head)))
+             (src-block-marker (save-excursion
+                                 (goto-char org-babel-current-src-block-location)
+                                 (point-marker)))
              (info (if info (copy-tree info) (org-babel-get-src-block-info))))
         ;; Merge PARAMS with INFO before considering source block
         ;; evaluation since both could disagree.
@@ -162,7 +165,7 @@ block."
                         (with-current-buffer ,(current-buffer)
                           (let ((default-directory ,default-directory))
                             (save-excursion
-                              (goto-char ,org-babel-current-src-block-location)
+                              (goto-char ,src-block-marker)
                               (let ((file (cdr (assq :file ',params))))
                                 ;; If non-empty result and :file then write to :file.
                                 (when file

--- a/ob-async.el
+++ b/ob-async.el
@@ -162,14 +162,7 @@ block."
                         (with-current-buffer ,(current-buffer)
                           (let ((default-directory ,default-directory))
                             (save-excursion
-                              (goto-char (point-min))
-                              (re-search-forward ,placeholder)
-                              (org-backward-element)
-                              (let ((result-block (split-string (thing-at-point 'line t))))
-                                ;; If block has name, search by name
-                                (-if-let (block-name (nth 1 result-block))
-                                    (org-babel-goto-named-src-block block-name)
-                                  (org-backward-element)))
+                              (goto-char ,org-babel-current-src-block-location)
                               (let ((file (cdr (assq :file ',params))))
                                 ;; If non-empty result and :file then write to :file.
                                 (when file

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -1,4 +1,5 @@
 (require 'subr-x)
+(require 'cl-macs)
 
 (defun placeholder-p (s)
   "Return non-nil if S is a placeholder for an asynchronous result."
@@ -12,13 +13,13 @@ If NAME is non-nil, find the results block by name."
     (progn
       (if name
           (org-babel-goto-named-result name)
-        (if-let ((result-pos (org-babel-where-is-src-block-result)))
+        (-if-let ((result-pos (org-babel-where-is-src-block-result)))
             (goto-char result-pos)
-          (assert (progn
-                    (goto-char (point-min))
-                    (re-search-forward "#\\+RESULT"))
-                  nil
-                  "Couldn't find a RESULTS block")))
+          (cl-assert (progn
+                       (goto-char (point-min))
+                       (re-search-forward "#\\+RESULT"))
+                     nil
+                     "Couldn't find a RESULTS block")))
       (let ((result (org-babel-read-result)))
         (message "RESULTS: %s" result)
         result))))

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -4,17 +4,21 @@
   "Return non-nil if S is a placeholder for an asynchronous result."
   (and (= 32 (length s)) (string-match-p "^[a-z0-9]\\{32\\}$" s)))
 
-(defun results-block-contents (&optional position)
+(defun results-block-contents (&optional name)
   "Return the contents of the *only* results block in the buffer.
-Assume the source block is at POSITION if non-nil."
+If NAME is non-nil, find the results block by name."
   (interactive)
   (save-excursion
     (progn
-      (if position
-          (goto-char position)
-        (goto-char 0)
-        (org-babel-next-src-block))
-      (goto-char (org-babel-where-is-src-block-result))
+      (if name
+          (org-babel-goto-named-result name)
+        (if-let ((result-pos (org-babel-where-is-src-block-result)))
+            (goto-char result-pos)
+          (assert (progn
+                    (goto-char (point-min))
+                    (re-search-forward "#\\+RESULT"))
+                  nil
+                  "Couldn't find a RESULTS block")))
       (let ((result (org-babel-read-result)))
         (message "RESULTS: %s" result)
         result))))
@@ -248,6 +252,36 @@ for row in x:
                                                      (point-marker))))
                             (should (< results-block-pos src-block-pos))))))
 
+(ert-deftest test-async-execute-named-call-block ()
+  "Test that we can asynchronously execute a named call block ."
+  (let ((buffer-contents "
+  #+NAME: test
+  #+CALL: async-block()
+
+  Here's a shell source block:
+
+  #+NAME: async-block
+  #+BEGIN_SRC sh :async
+     echo 'Sorry for the wait.'
+  #+END_SRC "))
+    (with-buffer-contents buffer-contents
+      (re-search-forward "#\\+NAME: test")
+      (org-ctrl-c-ctrl-c)
+      (let ((results-block-pos (save-excursion
+                                 (org-babel-goto-named-result "test")
+                                 (point-marker)))
+            (src-block-pos (save-excursion
+                             (org-babel-goto-named-src-block "async-block")
+                             (point-marker))))
+        (should (< results-block-pos src-block-pos))
+        (goto-char results-block-pos)
+        (should (placeholder-p (results-block-contents "test")))
+;(string-trim (org-element-property :value (org-element-at-point)))
+        (wait-for-seconds 5)
+        (should (string= "Sorry for the wait."
+                         (string-trim (org-element-property :value (org-element-at-point)))))))))
+
+
 (ert-deftest test-async-execute-silent-block ()
   "Test that we can insert results for a sh block that hasn't been executed yet"
   :expected-result :failed
@@ -273,11 +307,11 @@ for row in x:
 
   #+CALL: async-block()"))
     (with-buffer-contents buffer-contents
-                          (let ((position (re-search-forward "#\\+CALL")))
-                            (org-ctrl-c-ctrl-c)
-                            (should (placeholder-p (results-block-contents position)))
-                            (wait-for-seconds 5)
-                            (should (string= "Sorry for the wait." (results-block-contents position)))))))
+                          (re-search-forward "#\\+CALL")
+                          (org-ctrl-c-ctrl-c)
+                          (should (placeholder-p (results-block-contents)))
+                          (wait-for-seconds 5)
+                          (should (string= "Sorry for the wait." (results-block-contents))))))
 
 (ert-deftest test-confirm-evaluate ()
   "Test that we do not add a RESULTS block if evaluation is not confirmed"

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -212,7 +212,7 @@ for row in x:
 (ert-deftest test-async-execute-named-block ()
   "Test that we can asynchronously execute a block when cursor is on the name."
   (let ((buffer-contents "Here's a shell source block:
-  #+NAME: async-block
+  #+NAME: async block with spaces in the name
   #+BEGIN_SRC sh :async
      sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC"))
@@ -226,9 +226,9 @@ for row in x:
 (ert-deftest test-async-execute-named-block-with-results ()
   "Test that we can asynchronously execute a named block when results are anywhere in buffer."
   (let ((buffer-contents "Here's a shell source block:
-  #+RESULTS: async-block
+  #+RESULTS: async block with spaces in the name
 
-  #+NAME: async-block
+  #+NAME: async block with spaces in the name
   #+BEGIN_SRC sh :async
      sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC"))
@@ -237,7 +237,16 @@ for row in x:
                           (org-ctrl-c-ctrl-c)
                           (should (placeholder-p (results-block-contents)))
                           (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents))))))
+                          (should (string= "Sorry for the wait." (results-block-contents)))
+                          (let ((results-block-pos (save-excursion
+                                                     (goto-char (point-min))
+                                                     (re-search-forward "#\\+RESULTS")
+                                                     (point-marker)))
+                                (src-block-pos (save-excursion
+                                                     (goto-char (point-min))
+                                                     (re-search-forward "#\\+BEGIN_SRC")
+                                                     (point-marker))))
+                            (should (< results-block-pos src-block-pos))))))
 
 (ert-deftest test-async-execute-silent-block ()
   "Test that we can insert results for a sh block that hasn't been executed yet"

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -277,10 +277,9 @@ for row in x:
         (should (< results-block-pos src-block-pos))
         (goto-char results-block-pos)
         (should (placeholder-p (results-block-contents "test")))
-;(string-trim (org-element-property :value (org-element-at-point)))
         (wait-for-seconds 5)
         (should (string= "Sorry for the wait."
-                         (string-trim (org-element-property :value (org-element-at-point)))))))))
+                         (results-block-contents "test")))))))
 
 
 (ert-deftest test-async-execute-silent-block ()

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -1,5 +1,6 @@
 (require 'subr-x)
 (require 'cl-macs)
+(require 'cl-lib)
 
 (defun placeholder-p (s)
   "Return non-nil if S is a placeholder for an asynchronous result."
@@ -35,12 +36,31 @@ If NAME is non-nil, find the results block by name."
          (goto-char 0)
          ,@forms))))
 
-(defun wait-for-seconds (n)
-  "Sleep for N seconds.  This is a workaround for a bug in sleep-for.
-See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-when-running-a-test-in-ert"
-  (let ((deadline (+ n (float-time))))
-    (while (< (float-time) deadline)
-      (sleep-for 1))))
+(defmacro ctrl-c-ctrl-c-with-callbacks (pre-callback pre-form post-callback post-form)
+  "Run `org-ctrl-c-ctrl-c' with the supplied :pre and :post callbacks.
+
+PRE-FORM is executed immediately after running `org-ctrl-c-ctrl-c'
+POST-FORM is executed after the src-block finishes execution"
+  (declare (debug (":pre" form ":post" form)))
+  (let ((finished (cl-gensym))
+        (sleep-interval-seconds (cl-gensym))
+        (timeout-seconds (cl-gensym))
+        (max-attempts (cl-gensym))
+        (num-attempts (cl-gensym)))
+    `(let* ((,finished nil)
+            (,sleep-interval-seconds .5)
+            (,timeout-seconds 10)
+            (,max-attempts (/ ,timeout-seconds ,sleep-interval-seconds))
+            (,num-attempts 0)
+            (org-babel-after-execute-hook (list (lambda ()
+                                                  ,post-form
+                                                  (setq ,finished t)))))
+       (org-ctrl-c-ctrl-c)
+       ,pre-form
+       (while (and
+               (not ,finished)
+               (<= (cl-incf ,num-attempts) ,max-attempts))
+         (sleep-for ,sleep-interval-seconds)))))
 
 (ert-deftest test-async-execute-fresh-sh-block ()
   "Test that we can insert results for a sh block that hasn't been executed yet"
@@ -51,10 +71,9 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= "Sorry for the wait." (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (string= "Sorry for the wait." (results-block-contents)))))))
 
 
 (ert-deftest test-async-ignore-lang-sh-block ()
@@ -79,16 +98,14 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= "Sorry for the wait." (results-block-contents)))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (string= "Sorry for the wait." (results-block-contents))))
       (goto-char 0)
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= "Sorry for the wait." (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (string= "Sorry for the wait." (results-block-contents)))))))
 
 (ert-deftest test-async-execute-python-block ()
   "Test that we can insert results for a sh block that hasn't been executed yet"
@@ -99,10 +116,9 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (= 2 (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (= 2 (results-block-contents)))))))
 
 (ert-deftest test-async-return-to-point-above-block ()
   "Test that results are inserted in the correct location
@@ -114,18 +130,31 @@ when content has been added above the source block"
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (re-search-backward "block:")
-      (end-of-line)
-      (newline-and-indent)
-      (insert "Here's some more stuff while we're waiting")
-      (let ((captured-point (point)))
-        (wait-for-seconds 5)
-        (should (= 2 (results-block-contents)))
-        (should (= captured-point (point)))
-        (should (re-search-backward "some more stuff"))
-        (should (re-search-forward "BEGIN_SRC python"))))))
+      (let (captured-point done-with-callback)
+        (ctrl-c-ctrl-c-with-callbacks
+         :pre (progn
+                (should (placeholder-p (results-block-contents)))
+                (re-search-backward "block:")
+                (end-of-line)
+                (newline-and-indent)
+                (insert "Here's some more stuff while we're waiting")
+                (setq captured-point (point)))
+         :post (progn
+                 (should (= 2 (results-block-contents)))
+                 (should (re-search-backward "some more stuff"))
+                 (should (re-search-forward "BEGIN_SRC python"))
+                 (setq done-with-callback t)))
+        ;; Our :post callback runs inside the context of
+        ;; `org-babel-execute-src-block:async'. We specifically want
+        ;; to check where (point) is when all our callbacks are
+        ;; finished, hence this sentinel
+        (let* ((sleep-interval-seconds .05)
+               (five-seconds 5)
+               (deadline (+ five-seconds (float-time))))
+          (while (and (not done-with-callback)
+                      (< (float-time) deadline))
+            (sleep-for sleep-interval-seconds)))
+        (should (= captured-point (point)))))))
 
 (ert-deftest test-async-return-to-point-below-block ()
   "Test that results are inserted in the correct location
@@ -137,19 +166,32 @@ when content has been added below the source block"
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (goto-char (point-max))
-      (newline-and-indent)
-      (insert "Here's some more stuff while we're waiting")
-      (let* ((captured-point (point))
-             (expected-point (- captured-point (- (length (ob-async--generate-uuid))
-                                                  (length "2")))))
-        (wait-for-seconds 5)
-        (should (= 2 (results-block-contents)))
-        (should (= expected-point (point)))
-        (should (re-search-backward "some more stuff"))
-        (should (re-search-backward "END_SRC"))))))
+      (let (captured-point done-with-callback)
+        (ctrl-c-ctrl-c-with-callbacks
+         :pre (progn
+                (should (placeholder-p (results-block-contents)))
+                (goto-char (point-max))
+                (newline-and-indent)
+                (insert "Here's some more stuff while we're waiting")
+                (setq captured-point (point)))
+         :post (progn
+                 (should (= 2 (results-block-contents)))
+                 (setq done-with-callback t)))
+        ;; Our :post callback runs inside the context of
+        ;; `org-babel-execute-src-block:async'. We specifically want
+        ;; to check where (point) is when all our callbacks are
+        ;; finished, hence this sentinel
+        (let* ((sleep-interval-seconds .05)
+               (five-seconds 5)
+               (deadline (+ five-seconds (float-time))))
+          (while (and (not done-with-callback)
+                      (< (float-time) deadline))
+            (sleep-for sleep-interval-seconds)))
+        (let ((expected-point (- captured-point (- (length (ob-async--generate-uuid))
+                                                   (length "2")))))
+          (should (= expected-point (point)))
+          (should (re-search-backward "some more stuff"))
+          (should (re-search-backward "END_SRC")))))))
 
 (ert-deftest test-async-execute-file-block ()
   "Test that we can insert results when header-arg :file is present"
@@ -160,12 +202,12 @@ when content has been added below the source block"
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= "/tmp/foo" (results-block-contents)))
-      (let ((foo-contents (progn (find-file "/tmp/foo") (buffer-substring-no-properties (point-min) (point-max)))))
-        (should (string= "Don't wait on me\n" foo-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (progn
+               (should (string= "/tmp/foo" (results-block-contents)))
+               (let ((foo-contents (progn (find-file "/tmp/foo") (buffer-substring-no-properties (point-min) (point-max)))))
+                 (should (string= "Don't wait on me\n" foo-contents))))))))
 
 (ert-deftest test-async-execute-table-output ()
   "Test that we can insert table output"
@@ -178,12 +220,10 @@ for row in x:
 #+END_SRC"))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (message "Waiting")
-      (wait-for-seconds 8)
-      (should (equal '(("1,1" "1,2") ("2,1" "2,2")) (results-block-contents)))
-      (message "%s" (results-block-contents)))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (equal '(("1,1" "1,2") ("2,1" "2,2"))
+                            (results-block-contents)))))))
 
 (ert-deftest test-async-execute-tramp-block ()
   "Test that we can execute a block via Tramp with a :dir header-arg"
@@ -194,13 +234,13 @@ for row in x:
   #+END_SRC" user-login-name)))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= (format "%s /" user-login-name) (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (string= (format "%s /" user-login-name)
+                              (results-block-contents)))))))
 
 (ert-deftest test-async-ctrl-c-ctrl-c-hook ()
-  "Test that asynchronous execution works with org-ctrl-c-ctrl-c-hook."
+  "Test that asynchronous execution works with ctrl-c-ctrl-c-hook."
   (let ((buffer-contents "Here's a shell source block:
 
   #+BEGIN_SRC sh :async
@@ -209,10 +249,10 @@ for row in x:
         (org-ctrl-c-ctrl-c-hook '(ob-async-org-babel-execute-src-block)))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= "Sorry for the wait." (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (string= "Sorry for the wait."
+                              (results-block-contents)))))))
 
 (ert-deftest test-async-execute-named-block ()
   "Test that we can asynchronously execute a block when cursor is on the name."
@@ -223,10 +263,10 @@ for row in x:
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (re-search-forward "#\\+NAME")
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= "Sorry for the wait." (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (string= "Sorry for the wait."
+                              (results-block-contents)))))))
 
 (ert-deftest test-async-execute-named-block-with-results ()
   "Test that we can asynchronously execute a named block when results are anywhere in buffer."
@@ -239,19 +279,20 @@ for row in x:
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (re-search-forward "#\\+NAME")
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= "Sorry for the wait." (results-block-contents)))
-      (let ((results-block-pos (save-excursion
-                                 (goto-char (point-min))
-                                 (re-search-forward "#\\+RESULTS")
-                                 (point-marker)))
-            (src-block-pos (save-excursion
-                             (goto-char (point-min))
-                             (re-search-forward "#\\+BEGIN_SRC")
-                             (point-marker))))
-        (should (< results-block-pos src-block-pos))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (progn
+               (should (string= "Sorry for the wait."
+                                (results-block-contents)))
+               (let ((results-block-pos (save-excursion
+                                          (goto-char (point-min))
+                                          (re-search-forward "#\\+RESULTS")
+                                          (point-marker)))
+                     (src-block-pos (save-excursion
+                                      (goto-char (point-min))
+                                      (re-search-forward "#\\+BEGIN_SRC")
+                                      (point-marker))))
+                 (should (< results-block-pos src-block-pos))))))))
 
 (ert-deftest test-async-execute-named-call-block ()
   "Test that we can asynchronously execute a named call block ."
@@ -267,23 +308,21 @@ for row in x:
   #+END_SRC "))
     (with-buffer-contents buffer-contents
       (re-search-forward "#\\+NAME: test")
-      (org-ctrl-c-ctrl-c)
-      (let ((results-block-pos (save-excursion
-                                 (org-babel-goto-named-result "test")
-                                 (point-marker)))
-            (src-block-pos (save-excursion
-                             (org-babel-goto-named-src-block "async-block")
-                             (point-marker))))
-        (should (< results-block-pos src-block-pos))
-        (goto-char results-block-pos)
-        (should (placeholder-p (results-block-contents "test")))
-        (wait-for-seconds 5)
-        (should (string= "Sorry for the wait."
-                         (results-block-contents "test")))))))
-
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents "test")))
+       :post (let ((results-block-pos (save-excursion
+                                        (org-babel-goto-named-result "test")
+                                        (point-marker)))
+                   (src-block-pos (save-excursion
+                                    (org-babel-goto-named-src-block "async-block")
+                                    (point-marker))))
+               (should (< results-block-pos src-block-pos))
+               (goto-char results-block-pos)
+               (should (string= "Sorry for the wait."
+                                (results-block-contents "test"))))))))
 
 (ert-deftest test-async-execute-silent-block ()
-  "Test that we can insert results for a sh block that hasn't been executed yet"
+  "Test that silent blocks should have no output"
   :expected-result :failed
   (let ((buffer-contents "Here's a sh source block:
 
@@ -292,10 +331,9 @@ for row in x:
   #+END_SRC"))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (not (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (not (results-block-contents)))))))
 
 (ert-deftest test-async-execute-call ()
   "Test that we can asynchronously execute a #+CALL element."
@@ -308,10 +346,10 @@ for row in x:
   #+CALL: async-block()"))
     (with-buffer-contents buffer-contents
       (re-search-forward "#\\+CALL")
-      (org-ctrl-c-ctrl-c)
-      (should (placeholder-p (results-block-contents)))
-      (wait-for-seconds 5)
-      (should (string= "Sorry for the wait." (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (string= "Sorry for the wait."
+                       (results-block-contents)))))))
 
 (ert-deftest test-confirm-evaluate ()
   "Test that we do not add a RESULTS block if evaluation is not confirmed"
@@ -336,9 +374,9 @@ for row in x:
                                                  (setq this-function-is-defined-in-a-hook #'+)))))
     (with-buffer-contents buffer-contents
       (org-babel-next-src-block)
-      (org-ctrl-c-ctrl-c)
-      (wait-for-seconds 5)
-      (should (= 2 (results-block-contents))))))
+      (ctrl-c-ctrl-c-with-callbacks
+       :pre (should (placeholder-p (results-block-contents)))
+       :post (should (= 2 (results-block-contents)))))))
 
 (ert-deftest test-output-to-file-with-dir ()
   "Test that :file paths are resolved referenced relative to :dir"
@@ -347,19 +385,17 @@ for row in x:
          (buffer-contents (format "
 #+BEGIN_SRC sh :dir /tmp :file %s :async
   echo %s
-#+END_SRC"
-                                  output-file
-                                  uuid)))
+#+END_SRC" output-file uuid)))
     (unwind-protect
         (progn
           (with-buffer-contents buffer-contents
             (org-babel-next-src-block)
-            (org-ctrl-c-ctrl-c)
-            (wait-for-seconds 5))
-          (let ((retrieved-value (with-temp-buffer
-                                   (insert-file-contents (expand-file-name output-file "/tmp"))
-                                   (string-trim (buffer-string)))))
-            (should (string= uuid retrieved-value))))
+            (ctrl-c-ctrl-c-with-callbacks
+             :pre (should (placeholder-p (results-block-contents)))
+             :post (let ((retrieved-value (with-temp-buffer
+                                            (insert-file-contents (expand-file-name output-file "/tmp"))
+                                            (string-trim (buffer-string)))))
+                     (should (string= uuid retrieved-value))))))
       ;; Clean up after ourselves
       (when (file-exists-p output-file)
         (delete-file output-file)))))

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -60,7 +60,9 @@ POST-FORM is executed after the src-block finishes execution"
        (while (and
                (not ,finished)
                (<= (cl-incf ,num-attempts) ,max-attempts))
-         (sleep-for ,sleep-interval-seconds)))))
+         (sleep-for ,sleep-interval-seconds))
+       (when (not ,finished)
+         (ert-fail "Timed out waiting for src-block execution to complete")))))
 
 (ert-deftest test-async-execute-fresh-sh-block ()
   "Test that we can insert results for a sh block that hasn't been executed yet"

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -50,11 +50,11 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
       sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= "Sorry for the wait." (results-block-contents))))))
 
 
 (ert-deftest test-async-ignore-lang-sh-block ()
@@ -66,9 +66,9 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
   #+END_SRC")
 	(ob-async-no-async-languages-alist '("sh")))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (string= "Sorry for the wait." (results-block-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (string= "Sorry for the wait." (results-block-contents))))))
 
 (ert-deftest test-async-execute-existing-sh-block ()
   "Test that we can insert results for a sh block that has already been executed"
@@ -78,17 +78,17 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
      sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents)))
-                          (goto-char 0)
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= "Sorry for the wait." (results-block-contents)))
+      (goto-char 0)
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= "Sorry for the wait." (results-block-contents))))))
 
 (ert-deftest test-async-execute-python-block ()
   "Test that we can insert results for a sh block that hasn't been executed yet"
@@ -98,11 +98,11 @@ See http://stackoverflow.com/questions/14698081/elisp-sleep-for-doesnt-block-whe
       return 1 + 1
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (= 2 (results-block-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (= 2 (results-block-contents))))))
 
 (ert-deftest test-async-return-to-point-above-block ()
   "Test that results are inserted in the correct location
@@ -113,19 +113,19 @@ when content has been added above the source block"
       return 1 + 1
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (re-search-backward "block:")
-                          (end-of-line)
-                          (newline-and-indent)
-                          (insert "Here's some more stuff while we're waiting")
-                          (let ((captured-point (point)))
-                            (wait-for-seconds 5)
-                            (should (= 2 (results-block-contents)))
-                            (should (= captured-point (point)))
-                            (should (re-search-backward "some more stuff"))
-                            (should (re-search-forward "BEGIN_SRC python"))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (re-search-backward "block:")
+      (end-of-line)
+      (newline-and-indent)
+      (insert "Here's some more stuff while we're waiting")
+      (let ((captured-point (point)))
+        (wait-for-seconds 5)
+        (should (= 2 (results-block-contents)))
+        (should (= captured-point (point)))
+        (should (re-search-backward "some more stuff"))
+        (should (re-search-forward "BEGIN_SRC python"))))))
 
 (ert-deftest test-async-return-to-point-below-block ()
   "Test that results are inserted in the correct location
@@ -136,20 +136,20 @@ when content has been added below the source block"
       return 1 + 1
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (goto-char (point-max))
-                          (newline-and-indent)
-                          (insert "Here's some more stuff while we're waiting")
-                          (let* ((captured-point (point))
-                                 (expected-point (- captured-point (- (length (ob-async--generate-uuid))
-                                                                      (length "2")))))
-                            (wait-for-seconds 5)
-                            (should (= 2 (results-block-contents)))
-                            (should (= expected-point (point)))
-                            (should (re-search-backward "some more stuff"))
-                            (should (re-search-backward "END_SRC"))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (goto-char (point-max))
+      (newline-and-indent)
+      (insert "Here's some more stuff while we're waiting")
+      (let* ((captured-point (point))
+             (expected-point (- captured-point (- (length (ob-async--generate-uuid))
+                                                  (length "2")))))
+        (wait-for-seconds 5)
+        (should (= 2 (results-block-contents)))
+        (should (= expected-point (point)))
+        (should (re-search-backward "some more stuff"))
+        (should (re-search-backward "END_SRC"))))))
 
 (ert-deftest test-async-execute-file-block ()
   "Test that we can insert results when header-arg :file is present"
@@ -159,13 +159,13 @@ when content has been added below the source block"
      echo \"Don't wait on me\"
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= "/tmp/foo" (results-block-contents)))
-                          (let ((foo-contents (progn (find-file "/tmp/foo") (buffer-substring-no-properties (point-min) (point-max)))))
-                            (should (string= "Don't wait on me\n" foo-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= "/tmp/foo" (results-block-contents)))
+      (let ((foo-contents (progn (find-file "/tmp/foo") (buffer-substring-no-properties (point-min) (point-max)))))
+        (should (string= "Don't wait on me\n" foo-contents))))))
 
 (ert-deftest test-async-execute-table-output ()
   "Test that we can insert table output"
@@ -177,13 +177,13 @@ for row in x:
     print('{}\\n'.format(x))
 #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (message "Waiting")
-                          (wait-for-seconds 8)
-                          (should (equal '(("1,1" "1,2") ("2,1" "2,2")) (results-block-contents)))
-                          (message "%s" (results-block-contents)))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (message "Waiting")
+      (wait-for-seconds 8)
+      (should (equal '(("1,1" "1,2") ("2,1" "2,2")) (results-block-contents)))
+      (message "%s" (results-block-contents)))))
 
 (ert-deftest test-async-execute-tramp-block ()
   "Test that we can execute a block via Tramp with a :dir header-arg"
@@ -193,11 +193,11 @@ for row in x:
      echo $SUDO_USER $PWD
   #+END_SRC" user-login-name)))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= (format "%s /" user-login-name) (results-block-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= (format "%s /" user-login-name) (results-block-contents))))))
 
 (ert-deftest test-async-ctrl-c-ctrl-c-hook ()
   "Test that asynchronous execution works with org-ctrl-c-ctrl-c-hook."
@@ -208,11 +208,11 @@ for row in x:
   #+END_SRC")
         (org-ctrl-c-ctrl-c-hook '(ob-async-org-babel-execute-src-block)))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= "Sorry for the wait." (results-block-contents))))))
 
 (ert-deftest test-async-execute-named-block ()
   "Test that we can asynchronously execute a block when cursor is on the name."
@@ -222,11 +222,11 @@ for row in x:
      sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (re-search-forward "#\\+NAME")
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents))))))
+      (re-search-forward "#\\+NAME")
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= "Sorry for the wait." (results-block-contents))))))
 
 (ert-deftest test-async-execute-named-block-with-results ()
   "Test that we can asynchronously execute a named block when results are anywhere in buffer."
@@ -238,20 +238,20 @@ for row in x:
      sleep 1s && echo 'Sorry for the wait.'
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (re-search-forward "#\\+NAME")
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents)))
-                          (let ((results-block-pos (save-excursion
-                                                     (goto-char (point-min))
-                                                     (re-search-forward "#\\+RESULTS")
-                                                     (point-marker)))
-                                (src-block-pos (save-excursion
-                                                     (goto-char (point-min))
-                                                     (re-search-forward "#\\+BEGIN_SRC")
-                                                     (point-marker))))
-                            (should (< results-block-pos src-block-pos))))))
+      (re-search-forward "#\\+NAME")
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= "Sorry for the wait." (results-block-contents)))
+      (let ((results-block-pos (save-excursion
+                                 (goto-char (point-min))
+                                 (re-search-forward "#\\+RESULTS")
+                                 (point-marker)))
+            (src-block-pos (save-excursion
+                             (goto-char (point-min))
+                             (re-search-forward "#\\+BEGIN_SRC")
+                             (point-marker))))
+        (should (< results-block-pos src-block-pos))))))
 
 (ert-deftest test-async-execute-named-call-block ()
   "Test that we can asynchronously execute a named call block ."
@@ -291,11 +291,11 @@ for row in x:
   echo \"Don't wait on me\"
   #+END_SRC"))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (not (results-block-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (not (results-block-contents))))))
 
 (ert-deftest test-async-execute-call ()
   "Test that we can asynchronously execute a #+CALL element."
@@ -307,11 +307,11 @@ for row in x:
 
   #+CALL: async-block()"))
     (with-buffer-contents buffer-contents
-                          (re-search-forward "#\\+CALL")
-                          (org-ctrl-c-ctrl-c)
-                          (should (placeholder-p (results-block-contents)))
-                          (wait-for-seconds 5)
-                          (should (string= "Sorry for the wait." (results-block-contents))))))
+      (re-search-forward "#\\+CALL")
+      (org-ctrl-c-ctrl-c)
+      (should (placeholder-p (results-block-contents)))
+      (wait-for-seconds 5)
+      (should (string= "Sorry for the wait." (results-block-contents))))))
 
 (ert-deftest test-confirm-evaluate ()
   "Test that we do not add a RESULTS block if evaluation is not confirmed"
@@ -322,9 +322,9 @@ for row in x:
         (org-confirm-babel-evaluate t)
         (org-babel-confirm-evaluate-answer-no t))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (should (not (org-babel-where-is-src-block-result))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (not (org-babel-where-is-src-block-result))))))
 
 (ert-deftest test-pre-execute-hook ()
   "Test that we can use a hook to perform setup before async execution"
@@ -335,10 +335,10 @@ for row in x:
         (ob-async-pre-execute-src-block-hook '((lambda ()
                                                  (setq this-function-is-defined-in-a-hook #'+)))))
     (with-buffer-contents buffer-contents
-                          (org-babel-next-src-block)
-                          (org-ctrl-c-ctrl-c)
-                          (wait-for-seconds 5)
-                          (should (= 2 (results-block-contents))))))
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (wait-for-seconds 5)
+      (should (= 2 (results-block-contents))))))
 
 (ert-deftest test-output-to-file-with-dir ()
   "Test that :file paths are resolved referenced relative to :dir"


### PR DESCRIPTION
Stop sleeping for a fixed amount of time in our test cases while we
wait for results. Instead, add a macro that allows us to run code at
two points in time:

1. Immediately after executing `ctrl-c-ctrl-c`
2. After the src-block is done executing

The tests now run in roughly half the time that they took previously.