### PR TITLE
Test against Emacs 25 and 26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
 
 env:
   - EMACS_VERSION=24.5
-  - EMACS_VERSION=25
+  - EMACS_VERSION=25.3
   - EMACS_VERSION=26
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ git:
 
 env:
   - EMACS_VERSION=24.5
-  - EMACS_VERSION=25-prerelease
+  - EMACS_VERSION=25
+  - EMACS_VERSION=26
 
 install:
   - curl -LO https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz


### PR DESCRIPTION
Emacs 25 is no longer in pre-release. Also, Emacs 26 is out, so let's
test against that, too.