### PR TITLE
Fix invalid read syntax error when result overlays are hidden

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -155,7 +155,7 @@ block."
                       (setq exec-path ',exec-path)
                       (setq load-path ',load-path)
                       ;; setq any variables that are prefixed with "org-babel-"
-                      ,(async-inject-variables "\\borg-babel.+")
+                      ,(async-inject-variables "\\borg-babel.+" nil "^org-babel-hide-result-overlays$")
                       (package-initialize)
                       (setq ob-async-pre-execute-src-block-hook ',ob-async-pre-execute-src-block-hook)
                       (run-hooks 'ob-async-pre-execute-src-block-hook)

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -442,3 +442,20 @@ inherited by the async subprocess"
             (ctrl-c-ctrl-c-with-callbacks
              :pre (should (placeholder-p (results-block-contents)))
              :post (should (string= "I should be set!" (results-block-contents)))))))))
+
+(ert-deftest test-org-babel-hide-result-overlays-suppressed ()
+  "Test that org-babel-hide-result-overlays is not inherited by
+the async subprocess"
+  (let* ((uuid (ob-async--generate-uuid))
+         (buffer-contents "
+#+BEGIN_SRC emacs-lisp :async
+  org-babel-hide-result-overlays
+#+END_SRC"))
+    (unwind-protect
+        (progn
+          (with-buffer-contents buffer-contents
+            (setq org-babel-hide-result-overlays (list (make-overlay 1 1)))
+            (org-babel-next-src-block)
+            (ctrl-c-ctrl-c-with-callbacks
+             :pre (should (placeholder-p (results-block-contents)))
+             :post (should (string= "nil" (results-block-contents)))))))))


### PR DESCRIPTION
Prevent org-babel-hide-result-overlays from being inherited by the async process, because overlays are not readable and lead to the following error:

if: Invalid read syntax: "#"

See commit message.