### PR TITLE
Make async-inject variables customizable

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -48,6 +48,11 @@ functionality may be implemented separately.")
 block. You can use this hook to perform language-specific
 initialization which would normally execute in your init file.")
 
+(defvar ob-async-inject-variables "\\borg-babel.+"
+  "Regex of variables that should be injected into the async process.
+It's a good idea to include any variables that are prefixed with `org-babel'.
+Add additional variables like \"\\(\\borg-babel.+\\|sql-connection-alist\\)\".")
+
 ;;;###autoload
 (defalias 'org-babel-execute-src-block:async 'ob-async-org-babel-execute-src-block)
 
@@ -156,8 +161,7 @@ block."
                       ;; Initialize the new Emacs process with org-babel functions
                       (setq exec-path ',exec-path)
                       (setq load-path ',load-path)
-                      ;; setq any variables that are prefixed with "org-babel-"
-                      ,(async-inject-variables "\\borg-babel.+")
+                      ,(async-inject-variables ob-async-inject-variables)
                       (package-initialize)
                       (setq ob-async-pre-execute-src-block-hook ',ob-async-pre-execute-src-block-hook)
                       (run-hooks 'ob-async-pre-execute-src-block-hook)

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -443,6 +443,23 @@ inherited by the async subprocess"
              :pre (should (placeholder-p (results-block-contents)))
              :post (should (string= "I should be set!" (results-block-contents)))))))))
 
+(ert-deftest test-inject-variables-are-set-in-subprocess ()
+  "Test that variables in the `ob-sync-inject-variables' regex are
+inherited by the async subprocess"
+  (let* ((ob-async-inject-variables "\\(\\borg-babel.+\\|some-injected-variable\\)")
+         (some-injected-variable "I should be set!")
+         (uuid (ob-async--generate-uuid))
+         (buffer-contents "
+#+BEGIN_SRC emacs-lisp :async
+  some-injected-variable
+#+END_SRC"))
+    (unwind-protect
+        (progn
+          (with-buffer-contents buffer-contents
+            (org-babel-next-src-block)
+            (ctrl-c-ctrl-c-with-callbacks
+             :pre (should (placeholder-p (results-block-contents)))
+             :post (should (string= "I should be set!" (results-block-contents)))))))))
 
 (ert-deftest test-async-execute-with-ob-ref ()
   "Test that async subprocess works properly with ob-ref"


### PR DESCRIPTION
This gives users the option to inject different variables
that the need for execution of the source blocks.
E.g. to evaluate SQL SRC blocks with the :dbconnection
attribute you need to have `sql-connection-alist` set.