### PR TITLE
fix ob-async does not work with ob-ref  (#73)

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -140,6 +140,8 @@ block."
                        (or (and dir (file-name-as-directory (expand-file-name dir)))
                            default-directory))
                      (cmd (intern (concat "org-babel-execute:" lang)))
+                     (org-babel-async-content
+                      (buffer-substring-no-properties (point-min) (point-max)))
                      result)
                 (unless (fboundp cmd)
                   (error "No org-babel-execute function for %s!" lang))
@@ -161,7 +163,9 @@ block."
                       (run-hooks 'ob-async-pre-execute-src-block-hook)
                       (org-babel-do-load-languages 'org-babel-load-languages ',org-babel-load-languages)
                       (let ((default-directory ,default-directory))
-                        (,cmd ,body ',params)))
+                        (with-temp-buffer
+                          (insert org-babel-async-content)
+                          (,cmd ,body ',params))))
                    `(lambda (result)
                       (with-current-buffer ,(current-buffer)
                         (let ((default-directory ,default-directory))

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -442,3 +442,24 @@ inherited by the async subprocess"
             (ctrl-c-ctrl-c-with-callbacks
              :pre (should (placeholder-p (results-block-contents)))
              :post (should (string= "I should be set!" (results-block-contents)))))))))
+
+
+(ert-deftest test-async-execute-with-ob-ref ()
+  "Test that async subprocess works properly with ob-ref"
+  (let* ((uuid (ob-async--generate-uuid))
+         (buffer-contents "
+#+NAME: result
+#+begin_example
+success
+#+end_example
+
+#+BEGIN_SRC emacs-lisp :async
+(org-babel-ref-resolve \"result\")
+#+END_SRC"))
+    (unwind-protect
+        (progn
+          (with-buffer-contents buffer-contents
+                                (org-babel-next-src-block)
+                                (ctrl-c-ctrl-c-with-callbacks
+                                 :pre (should (placeholder-p (results-block-contents)))
+                                 :post (should (string= "success" (results-block-contents)))))))))


### PR DESCRIPTION
Add org-babel-async-content to pass current buffer