### PR TITLE
Option to ignore sessions only

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Example:
 For additional context, see
 https://github.com/astahlman/ob-async/pull/35.
 
+### ob-async-ignore-sessions
+
+This variable allows using `ob-async` for nonsession blocks, while
+using alternative `:async` implementations for session blocks. This
+may be useful for languages like `ob-python` and `ob-R`, which have
+built-in `:async` implementations for sessions, but don't handle
+`:async` for nonsessions.
+
+This variable can be a list, in which case it is like
+`ob-async-no-async-languages-alist` but for sessions
+only. Alternatively, it can be set to `t` to have `ob-async` always
+ignore session blocks.
+
 ### ob-async-pre-execute-src-block-hook
 
 Some org-babel languages require additional user configuration. For

--- a/ob-async.el
+++ b/ob-async.el
@@ -43,6 +43,12 @@
 compatibility for other languages, e.g. ipython, for which async
 functionality may be implemented separately.")
 
+(defvar ob-async-ignore-sessions '("python" "R")
+  "Don't try to use async in sessions for these languages.
+Like `ob-async-no-async-languages-alist', but only for
+sessions. Can alternatively be set to `t', in which case ob-async
+ignores sessions for all languages.")
+
 (defvar ob-async-pre-execute-src-block-hook nil
   "Hook run in the async child process prior to executing a src
 block. You can use this hook to perform language-specific
@@ -84,6 +90,14 @@ block."
     nil)
    ;; If there is no :async parameter, call the original function
    ((not (assoc :async (nth 2 (or info (org-babel-get-src-block-info)))))
+    (funcall orig-fun arg info params))
+   ;; If a session, check ob-async-ignore-sessions to determine
+   ;; whether to call the original function
+   ((and (assoc :session (nth 2 (or info (org-babel-get-src-block-info))))
+         (or (equal ob-async-ignore-sessions t)
+             (and (listp ob-async-ignore-sessions)
+                  (member (nth 0 (or info (org-babel-get-src-block-info)))
+                          ob-async-ignore-sessions))))
     (funcall orig-fun arg info params))
    ;; If the src block language is in the list of languages async is not to be
    ;; used for, call the original function


### PR DESCRIPTION
Since Org 9.5, some languages (currently Python and R) support the `:async` flag for sessions, but don't have async evaluation for nonsession blocks.

Currently, `ob-async` breaks the native async evaluation unless these languages are added to `ob-async-no-async-languages-alist`. However, doing so prevents using `ob-async` for nonsession blocks. It would be desirable to be able to use `ob-async` for nonsession blocks while using the native implementation for session blocks.

This PR adds an option `ob-async-ignore-sessions` that allows `ob-async` to ignore session blocks of a language, while still being able to use `ob-async` for the nonsession blocks.