### PR TITLE
Bump version to 1.0.1 for NonGNU ELPA

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -4,7 +4,7 @@
 
 ;; Author: Andrew Stahlman <andrewstahlman@gmail.com>
 ;; Created: 10 Feb 2017
-;; Version: 0.1
+;; Version: 0.2
 
 ;; Keywords: tools
 ;; Homepage: https://github.com/astahlman/ob-async


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the "Version" commentary header in this repository, as I do in this commit. In the future, you can bump the package version (thereby releasing a new version) when you think it makes sense and at your convenience.

The rules for accepting a package into NonGNU ELPA are here, for your reference:

https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n133

As far as I can tell, this package already follows the rules so there should be nothing more to do with regards to that. It would be good to add the license and copyright header to the test file as I have suggested separately.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!