### PR TITLE
troubleshooting.org: replace function incf by cl-incf

### DIFF
--- a/troubleshooting.org
+++ b/troubleshooting.org
@@ -43,7 +43,7 @@ First, let's make sure you can run a basic async process *without*
     (while (and
             (not (boundp 'ob-async/troubleshooting-sentinel))
             (< elapsed-secs deadline-secs))
-      (incf elapsed-secs)
+      (cl-incf elapsed-secs)
       (sleep-for 1)))
 
   (if (boundp 'ob-async/troubleshooting-sentinel)


### PR DESCRIPTION
The package cl is marked as deprecated, therefore replace the call to
function incf from the cl package with the function cl-incf.