### PR TITLE
troubleshooting.org: Rework code that gets the transmitted sexp

### DIFF
--- a/troubleshooting.org
+++ b/troubleshooting.org
@@ -97,10 +97,12 @@ still nothing obviously wrong, file an issue on GitHub and include the
 contents of this file as a Gist.
 
 #+BEGIN_SRC emacs-lisp
-  (switch-to-buffer "*Messages*")
-  (goto-char (point-max))
-  (re-search-backward "Transmitting sexp {{{\\([^}]+\\)}}}")
-  (match-string 1)
+  (with-current-buffer "*Messages*"
+    (goto-char (point-max))
+    (re-search-backward "^Transmitting sexp {{{")
+    (let ((beg (point)))
+      (forward-sexp 3)
+      (buffer-substring beg (point))))
 #+END_SRC
 
 * Bug Description


### PR DESCRIPTION
The code that should match and get the transmitted sexp from
the *Messages* buffer was not working for me, because my sexp
contained a closing curly brace '}'.  Replaced it by an implementation
that I deem as more robust.