### PR TITLE
Handle errors of code blocks and return them to the user

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -169,7 +169,12 @@ block."
                       (let ((default-directory ,default-directory))
                         (with-temp-buffer
                           (insert org-babel-async-content)
-                          (,cmd ,body ',params))))
+                          (condition-case context
+                              (,cmd ,body ',params)
+                            (error (format
+                                    "Failure: during the async execution of your code block the following error was signaled:\n   %s: %s"
+                                    (car context)
+                                    (cdr context)))))))
                    `(lambda (result)
                       (with-current-buffer ,(current-buffer)
                         (let ((default-directory ,default-directory))

--- a/ob-async.el
+++ b/ob-async.el
@@ -166,15 +166,26 @@ block."
                       (setq ob-async-pre-execute-src-block-hook ',ob-async-pre-execute-src-block-hook)
                       (run-hooks 'ob-async-pre-execute-src-block-hook)
                       (org-babel-do-load-languages 'org-babel-load-languages ',org-babel-load-languages)
-                      (let ((default-directory ,default-directory))
-                        (with-temp-buffer
-                          (insert org-babel-async-content)
-                          (condition-case context
-                              (,cmd ,body ',params)
-                            (error (format
-                                    "Failure: during the async execution of your code block the following error was signaled:\n   %s: %s"
-                                    (car context)
-                                    (cdr context)))))))
+                      (advice-add 'org-babel-eval-error-notify
+                                  :override
+                                  (lambda (exit-code stderr)
+                                    (setq ob-async-eval-error `(,exit-code . ,stderr))))
+                      (defvar ob-async-eval-error nil)
+                      (let ((default-directory ,default-directory)
+                            (retval (with-temp-buffer
+                                      (insert org-babel-async-content)
+                                      (condition-case context
+                                          (,cmd ,body ',params)
+                                        (error (format
+                                                "Failure: during the async execution of your code block the following error was signaled:\n   %s: %s"
+                                                (car context)
+                                                (cdr context)))))))
+                        (if ob-async-eval-error
+                            (format
+                             "Failure: the async execution of your code block returned with exit code %s!\nThe following output was captured on stderr:\n%s"
+                             (car ob-async-eval-error)
+                             (cdr ob-async-eval-error))
+                          retval)))
                    `(lambda (result)
                       (with-current-buffer ,(current-buffer)
                         (let ((default-directory ,default-directory))


### PR DESCRIPTION
During the execution of code-blocks some errors could go unnoticed.  This PR adds code that will return an error description to the user.  With this the following code blocks should return error messages instead of silently failing:

```
#+BEGIN_SRC emacs-lisp :async
(error "somewhere an error was signaled")
#+END_SRC
```

```
#+begin_src sh :results output :async
echo something went wrong >&2
false
#+end_src
```

```
#+begin_src python :async
raise NotImplementedError
#+end_src
```

See the individual commits for details.

And thanks for this awesome package.