### PR TITLE
feat: expose exclusion pattern for `async-inject-variables` as configuration var

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -48,10 +48,21 @@ functionality may be implemented separately.")
 block. You can use this hook to perform language-specific
 initialization which would normally execute in your init file.")
 
-(defvar ob-async-inject-variables "\\borg-babel.+"
+(defvar ob-async-inject-variables-inclusion-pattern "\\borg-babel.+"
   "Regex of variables that should be injected into the async process.
 It's a good idea to include any variables that are prefixed with `org-babel'.
 Add additional variables like \"\\(\\borg-babel.+\\|sql-connection-alist\\)\".")
+
+(defvaralias 'ob-async-inject-variables 'ob-async-inject-variables-inclusion-pattern)
+
+(defvar ob-async-inject-variables-exclusion-pattern "-overlay"
+  "Regex of variables to exclude injecting into the async process.
+It's a good idea to exclude variables that contain propertized text.
+
+Variables with values containing overlays may contain ‘-overlay’ in the name and
+are an example of variables to add to the exclusion pattern. Listing of
+additional variables can be conducted as is done with
+‘ob-async-inject-variable-inclusion-pattern’.")
 
 ;;;###autoload
 (defalias 'org-babel-execute-src-block:async 'ob-async-org-babel-execute-src-block)
@@ -161,7 +172,9 @@ block."
                       ;; Initialize the new Emacs process with org-babel functions
                       (setq exec-path ',exec-path)
                       (setq load-path ',load-path)
-                      ,(async-inject-variables ob-async-inject-variables)
+                      ,(async-inject-variables
+                        ob-async-inject-variables-inclusion-pattern nil
+                        ob-async-inject-variables-exclusion-pattern)
                       (package-initialize)
                       (setq ob-async-pre-execute-src-block-hook ',ob-async-pre-execute-src-block-hook)
                       (run-hooks 'ob-async-pre-execute-src-block-hook)


### PR DESCRIPTION
Some variables matching the pattern `org-babel-*` caused some trouble because they had propertized texts for values and thus weren't serializable in a manner that didn't break reading attempts.

Since `async-inject-variables` allows for the definition of exclusion patterns, I simply used this to reduce the set of vars that actually get injected into the async process.

The default value for the exclusion pattern will drop variables that contain `-overlay` as part of their names since these typically contain overlays which have those propertized texts in my setup.

The previous variable `ob-async-inject-variables`  has been kept as an alias for backwards compatibility.