### PR TITLE
Allow disabling `:async` by setting `:async no`

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -82,8 +82,9 @@ block."
    ((not orig-fun)
     (warn "ob-async-org-babel-execute-src-block is no longer needed in org-ctrl-c-ctrl-c-hook")
     nil)
-   ;; If there is no :async parameter, call the original function
-   ((not (assoc :async (nth 2 (or info (org-babel-get-src-block-info)))))
+   ;; If there is no `:async' parameter or we have `:async no', call the original function
+   ((let ((async-maybe (assoc :async (nth 2 (or info (org-babel-get-src-block-info))))))
+      (or (not async-maybe) (string-equal (cdr async-maybe) "no")))
     (funcall orig-fun arg info params))
    ;; If the src block language is in the list of languages async is not to be
    ;; used for, call the original function

--- a/test/ob-async-test.el
+++ b/test/ob-async-test.el
@@ -91,6 +91,18 @@ POST-FORM is executed after the src-block finishes execution"
       (org-ctrl-c-ctrl-c)
       (should (string= "Sorry for the wait." (results-block-contents))))))
 
+(ert-deftest test-async-no ()
+  "Testing ignoring async when `:async no' is set."
+  (let ((buffer-contents "Here's a shell source block:
+
+  #+BEGIN_SRC sh :async no
+      sleep 1s && echo 'Sorry for the wait.'
+  #+END_SRC"))
+    (with-buffer-contents buffer-contents
+      (org-babel-next-src-block)
+      (org-ctrl-c-ctrl-c)
+      (should (string= "Sorry for the wait." (results-block-contents))))))
+
 (ert-deftest test-async-execute-existing-sh-block ()
   "Test that we can insert results for a sh block that has already been executed"
   (let ((buffer-contents "Here's a shell source block:


### PR DESCRIPTION
I often find myself just taking a "async by default"-approach, e.g. by setting `:async` at the buffer-level. _But_ sometimes I'll run into issues with whatever command I'm running, in which case I will have to disable `:async`, and then re-run the block in sync-mode to get the error message. 

Note that #86 is also helpful in this regard, but even with that you might be losing useful output prior to error which is then subsequently dropped since only `stderr` is captured.

Hence, this PR introduces, in similar vein to many other header-args in Org, the ability to set `:async no` to disable async.

Thoughts?