### PR TITLE
ob-async: update function signature of ob-async-org-babel-execute-src…

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -57,7 +57,8 @@ Add additional variables like \"\\(\\borg-babel.+\\|sql-connection-alist\\)\".")
 (defalias 'org-babel-execute-src-block:async 'ob-async-org-babel-execute-src-block)
 
 ;;;###autoload
-(defun ob-async-org-babel-execute-src-block (&optional orig-fun arg info params)
+(defun ob-async-org-babel-execute-src-block ( &optional orig-fun arg info params
+                                              &rest other-args) ; since 9.6-3
   "Like org-babel-execute-src-block, but run asynchronously.
 
 Original docstring for org-babel-execute-src-block:
@@ -84,12 +85,12 @@ block."
     nil)
    ;; If there is no :async parameter, call the original function
    ((not (assoc :async (nth 2 (or info (org-babel-get-src-block-info)))))
-    (funcall orig-fun arg info params))
+    (apply orig-fun arg info params other-args))
    ;; If the src block language is in the list of languages async is not to be
    ;; used for, call the original function
    ((member (nth 0 (or info (org-babel-get-src-block-info)))
             ob-async-no-async-languages-alist)
-    (funcall orig-fun arg info params))
+    (apply orig-fun arg info params other-args))
    ;; Otherwise, perform asynchronous execution
    (t
     (let ((placeholder (ob-async--generate-uuid)))


### PR DESCRIPTION
…-block

Since 0625651e (Update to Org 9.6-3-ga4d38e) ob-async has been broken on the emacs-29 branch. Fix this by expanding the function to include the extra parameters.

This works but I'm unsure what effect it will have on older emacsen.

Fixes: #92
Signed-off-by: Alex Bennée <alex.bennee@linaro.org>