### PR TITLE
Update signature and skip :session blocks

### DIFF
--- a/ob-async.el
+++ b/ob-async.el
@@ -57,7 +57,8 @@ Add additional variables like \"\\(\\borg-babel.+\\|sql-connection-alist\\)\".")
 (defalias 'org-babel-execute-src-block:async 'ob-async-org-babel-execute-src-block)
 
 ;;;###autoload
-(defun ob-async-org-babel-execute-src-block (&optional orig-fun arg info params)
+(defun ob-async-org-babel-execute-src-block ( &optional orig-fun arg info params
+                                              &rest other-args) ; since 9.6-3
   "Like org-babel-execute-src-block, but run asynchronously.
 
 Original docstring for org-babel-execute-src-block:
@@ -84,12 +85,12 @@ block."
     nil)
    ;; If there is no :async parameter, call the original function
    ((not (assoc :async (nth 2 (or info (org-babel-get-src-block-info)))))
-    (funcall orig-fun arg info params))
+    (apply orig-fun arg info params other-args))
    ;; If the src block language is in the list of languages async is not to be
    ;; used for, call the original function
    ((member (nth 0 (or info (org-babel-get-src-block-info)))
             ob-async-no-async-languages-alist)
-    (funcall orig-fun arg info params))
+    (apply orig-fun arg info params other-args))
    ;; Otherwise, perform asynchronous execution
    (t
     (let ((placeholder (ob-async--generate-uuid)))

--- a/ob-async.el
+++ b/ob-async.el
@@ -58,6 +58,9 @@ Add additional variables like \"\\(\\borg-babel.+\\|sql-connection-alist\\)\".")
   (cond
    ;; If there is no :async parameter, call the original function
    ((not (assoc :async (nth 2 info))) t)
+   ;; If there is a :session parameter we are probably using the
+   ;; internal async support
+   ((assoc :session (nth 2 info)) t)
    ;; If the src block language is in the list of languages async is not to be
    ;; used for, call the original function
    ((member


### PR DESCRIPTION
I was running into issues with buffer references being passed when async evaluating python code (I suspect similar to what @vidbina was seeing in #88, #89).  As python has "native" :async support in the latest org-mode I wanted to use that without dumping ob-async entirely. This series does a light refactor on the skipping code and will also skip :session tagged jobs.

It also includes the previous PR #93.